### PR TITLE
remove set in frame properties, this will be done in the vizkit3d_wor…

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -73,8 +73,6 @@ void Task::updateHook()
     std::unique_ptr<Frame> frame(new Frame());
     vizkit3dWorld->grabFrame(*frame.get());
     frame->time = cameraPose.time;
-    frame->setStatus(base::samples::frame::STATUS_VALID);
-    frame->setFrameMode(base::samples::frame::MODE_RGB);
     _frame.write(RTT::extras::ReadOnlyPointer<Frame>(frame.release()));
 }
 


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-gazebo/gui-vizkit3d_world/pull/7

The frame pixel mode was set to a wrong mode here, while the one from vizkit3d_world
was set properly. Remove the override

Moreover, vizkit3d_world now sets the frame mode to VALID as should be.