### PR TITLE
convert to using qt_base::Task's hooks

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -25,14 +25,17 @@ Task::~Task()
 
 bool Task::configureHook()
 {
-    /**
-     * Apply the camera parameters
-     */
-    underwater_camera_simulation::CameraParams params = _camera_params.get();
-
-    if (! TaskBase::configureHook())
+    if (! TaskBase::configureHook()) {
         return false;
+    }
 
+    return true;
+}
+
+void Task::configureUI() {
+    TaskBase::configureUI();
+
+    underwater_camera_simulation::CameraParams params = _camera_params.get();
     vizkit3d::OceanParameters ocean_params = mapOceanParameters(_ocean_params.get());
     oceanEnvPlugin = new vizkit3d::Ocean(ocean_params);
 
@@ -47,30 +50,33 @@ bool Task::configureHook()
                                    params.horizontal_fov,
                                    params.near,
                                    params.far);
-
-    return true;
 }
 
-bool Task::startHook()
-{
-    if (! TaskBase::startHook())
+bool Task::startHook() {
+    if (! TaskBase::startHook()) {
         return false;
-
-
-    vizkit3dWorld->enableGrabbing();
+    }
     return true;
 }
+
+void Task::startUI() {
+    TaskBase::startUI();
+    vizkit3dWorld->enableGrabbing();
+}
+
 void Task::updateHook()
 {
     TaskBase::updateHook();
+}
+
+void Task::updateUI() {
+    TaskBase::updateUI();
 
     base::samples::RigidBodyState cameraPose;
     RTT::FlowStatus flow = _camera_pose.readNewest(cameraPose);
-    if (flow == RTT::NoData)
+    if (flow != RTT::NewData) {
         return;
-
-    if (flow != RTT::NewData)
-        return;
+    }
 
     vizkit3dWorld->setCameraPose(cameraPose);
 
@@ -87,10 +93,18 @@ void Task::errorHook()
 }
 void Task::stopHook()
 {
-    vizkit3dWorld->disableGrabbing();
     TaskBase::stopHook();
 }
+void Task::stopUI()
+{
+    vizkit3dWorld->disableGrabbing();
+    TaskBase::stopUI();
+}
 void Task::cleanupHook()
+{
+    TaskBase::cleanupHook();
+}
+void Task::cleanupUI()
 {
     //remove ocean plugin from memory
     if (oceanEnvPlugin){
@@ -99,10 +113,10 @@ void Task::cleanupHook()
         oceanEnvPlugin = NULL;
     }
 
-    TaskBase::cleanupHook();
+    TaskBase::cleanupUI();
 }
 
-vizkit3d::OceanParameters Task::mapOceanParameters(const OceanParameters& ocean_params) const 
+vizkit3d::OceanParameters Task::mapOceanParameters(const OceanParameters& ocean_params) const
 {
     vizkit3d::OceanParameters viz_ocean_params;
 
@@ -124,7 +138,7 @@ vizkit3d::OceanParameters Task::mapOceanParameters(const OceanParameters& ocean_
 
     viz_ocean_params.airFogColor = vector3DToQColor(ocean_params.airFogColor);
     viz_ocean_params.airFogDensity = ocean_params.airFogDensity;
-    viz_ocean_params.sunPosition = vector3DToQVector3D(ocean_params.sunPosition); 
+    viz_ocean_params.sunPosition = vector3DToQVector3D(ocean_params.sunPosition);
     viz_ocean_params.sunDiffuseColor = vector3DToQColor(ocean_params.sunDiffuseColor);
     viz_ocean_params.sunColor = vector3DToQColor(ocean_params.sunColor);
     viz_ocean_params.uwFogColor = vector3DToQColor(ocean_params.uwFogColor);
@@ -142,7 +156,7 @@ vizkit3d::OceanParameters Task::mapOceanParameters(const OceanParameters& ocean_
     viz_ocean_params.underwaterScattering = ocean_params.underwaterScattering;
     viz_ocean_params.distortion = ocean_params.distortion;
     viz_ocean_params.glare = ocean_params.glare;
-    
+
     return viz_ocean_params;
 }
 

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -9,11 +9,11 @@
 
 namespace underwater_camera_simulation {
 
-    /*! \class Task 
+    /*! \class Task
      * \brief The task context provides and requires services. It uses an ExecutionEngine to perform its functions.
      * Essential interfaces are operations, data flow ports and properties. These interfaces have been defined using the oroGen specification.
      * In order to modify the interfaces you should (re)use oroGen and rely on the associated workflow.
-     * 
+     *
      * \details
      * The name of a TaskContext is primarily defined via:
      \verbatim
@@ -21,7 +21,7 @@ namespace underwater_camera_simulation {
          task('custom_task_name','underwater_camera_simulation::Task')
      end
      \endverbatim
-     *  It can be dynamically adapted when the deployment is called with a prefix argument. 
+     *  It can be dynamically adapted when the deployment is called with a prefix argument.
      */
     class Task : public TaskBase
     {
@@ -32,6 +32,7 @@ namespace underwater_camera_simulation {
          */
         vizkit3d::Ocean *oceanEnvPlugin;
 
+        void configureUI();
         vizkit3d::OceanParameters mapOceanParameters(const OceanParameters& ocean_params) const;
         QColor vector3DToQColor(const base::Vector3d& vector) const;
         QVector3D vector3DToQVector3D(const base::Vector3d& vector) const;
@@ -44,10 +45,10 @@ namespace underwater_camera_simulation {
          */
         Task(std::string const& name = "underwater_camera_simulation::Task");
 
-        /** TaskContext constructor for Task 
-         * \param name Name of the task. This name needs to be unique to make it identifiable for nameservices. 
-         * \param engine The RTT Execution engine to be used for this task, which serialises the execution of all commands, programs, state machines and incoming events for a task. 
-         * 
+        /** TaskContext constructor for Task
+         * \param name Name of the task. This name needs to be unique to make it identifiable for nameservices.
+         * \param engine The RTT Execution engine to be used for this task, which serialises the execution of all commands, programs, state machines and incoming events for a task.
+         *
          */
         Task(std::string const& name, RTT::ExecutionEngine* engine);
 
@@ -77,6 +78,7 @@ namespace underwater_camera_simulation {
          * will be called.
          */
         bool startHook();
+        void startUI();
 
         /** This hook is called by Orocos when the component is in the Running
          * state, at each activity step. Here, the activity gives the "ticks"
@@ -84,7 +86,7 @@ namespace underwater_camera_simulation {
          *
          * The error(), exception() and fatal() calls, when called in this hook,
          * allow to get into the associated RunTimeError, Exception and
-         * FatalError states. 
+         * FatalError states.
          *
          * In the first case, updateHook() is still called, and recover() allows
          * you to go back into the Running state.  In the second case, the
@@ -93,6 +95,7 @@ namespace underwater_camera_simulation {
          * it again. Finally, FatalError cannot be recovered.
          */
         void updateHook();
+        void updateUI();
 
         /** This hook is called by Orocos when the component is in the
          * RunTimeError state, at each activity step. See the discussion in
@@ -106,12 +109,14 @@ namespace underwater_camera_simulation {
          * from Running to Stopped after stop() has been called.
          */
         void stopHook();
+        void stopUI();
 
         /** This hook is called by Orocos when the state machine transitions
          * from Stopped to PreOperational, requiring the call to configureHook()
          * before calling start() again.
          */
         void cleanupHook();
+        void cleanupUI();
     };
 }
 

--- a/underwater_camera_simulation.orogen
+++ b/underwater_camera_simulation.orogen
@@ -9,11 +9,9 @@ using_task_library "vizkit3d_world"
 import_types_from "base"
 import_types_from "underwater_camera_simulationTypes.hpp"
 
-task_context "Task" do
-    subclasses "vizkit3d_world::Task"
+task_context "Task", subclasses: 'vizkit3d_world::Task' do
     needs_configuration
 
-    #
     # enable camera manipulator
     # only work if showGui property is true
     #


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-gazebo/gui-orogen-vizkit3d_world/pull/3

Qt needs all GUI-related operations to be done in the same thread than the Qt application. The Qt initializer in orogen now creates the Qt application and calls exec within a single thread. qt_base provides a generic interface to run hook code within said thread.

In my tests, this fixes all initialization and reconfiguration related crashes for https://github.com/rock-gazebo/simulation-orogen-underwater_camera_simulation.

In addition, it allows to start multiple vizkit3d_world in the same process, and when doing so allows to share the OSG models (i.e. the actual triangle and texture data), thus dramatically reducing memory usage and initialization times.